### PR TITLE
[bug fix] drivers/binder: Rename BIOC_FLUSH to BINDER_FLUSH to avoid …

### DIFF
--- a/libs/binder/ProcessState.cpp
+++ b/libs/binder/ProcessState.cpp
@@ -137,7 +137,7 @@ void ProcessState::requestExit()
         size_t remain = mThreadPoolSet.count(gettid());
         do {
             ALOGD("flush thread");
-            ioctl(mDriverFD, BIOC_FLUSH, NULL);
+            ioctl(mDriverFD, BINDER_FLUSH, NULL);
             sched_yield();
         } while (mThreadPoolSet.size() > remain);
     }


### PR DESCRIPTION
…conflict with system flush.

*Note: Please adhere to [Contributing Guidelines](https://github.com/open-vela/docs/blob/dev/CONTRIBUTING.md).*

## Summary

## Impact

## Testing


